### PR TITLE
feat / fix / fmt : add CSV::header() & data() to allow to access data in `CSV` ; fix bug casue by CSVOptions `read-only` error ; update moon fmt

### DIFF
--- a/src/nyacsv.mbt
+++ b/src/nyacsv.mbt
@@ -14,7 +14,17 @@ struct CSV {
 }
 
 ///|
-impl Show for CSV with output(self, logger) -> Unit {
+pub fn CSV::header(self : CSV) -> Array[String] {
+  self.headers
+}
+
+///|
+pub fn CSV::data(self : CSV) -> Array[Array[String]] {
+  self.rows
+}
+
+///|
+pub impl Show for CSV with output(self, logger) -> Unit {
   if self.headers.is_empty() {
     logger.write_string("<Empty CSV>")
   } else {
@@ -92,14 +102,6 @@ impl Show for CSV with output(self, logger) -> Unit {
 }
 
 ///|
-test "CSV::output/empty_csv" {
-  let csv = CSV::new()
-  let logger = @buffer.new()
-  csv.output(logger)
-  inspect!(logger.contents().to_unchecked_string(), content="<Empty CSV>")
-}
-
-///|
 test "CSV::output/single_row_no_newline" {
   let csv = {
     headers: ["Name", "Age", "City"],
@@ -138,7 +140,7 @@ test "CSV::output/row_with_missing_fields" {
 }
 
 ///|
-impl Show for CSV with to_string(self) -> String {
+pub impl Show for CSV with to_string(self) -> String {
   let result = StringBuilder::new()
 
   // 添加表头
@@ -162,12 +164,6 @@ impl Show for CSV with to_string(self) -> String {
     result.write_char('\n')
   }
   result.to_string()
-}
-
-///|
-test "CSV::to_string/empty" {
-  let csv = CSV::new()
-  inspect!(csv.to_string(), content="\n")
 }
 
 ///|
@@ -209,7 +205,7 @@ test "CSV::new/basic" {
 }
 
 ///|
-fn CSV::from_array(
+pub fn CSV::from_array(
   data : Array[Array[String]],
   has_header~ : Bool = true,
   generate_headers~ : Bool = true
@@ -229,91 +225,6 @@ fn CSV::from_array(
     let headers = Array::make(column_count, "")
     { headers, rows: data }
   }
-}
-
-///|
-test "CSV::from_array/empty_data" {
-  let data : Array[Array[String]] = []
-  let csv = CSV::from_array(data)
-  inspect!(csv.headers, content="[]")
-  inspect!(csv.rows, content="[]")
-}
-
-///|
-test "CSV::from_array/header_present" {
-  let data : Array[Array[String]] = [
-    ["Name", "Age", "City"],
-    ["Alice", "30", "Wonderland"],
-  ]
-  let csv = CSV::from_array(data)
-  inspect!(csv.headers, content="[\"Name\", \"Age\", \"City\"]")
-  inspect!(csv.rows, content="[[\"Alice\", \"30\", \"Wonderland\"]]")
-}
-
-///|
-test "CSV::from_array/generate_headers" {
-  let data : Array[Array[String]] = [
-    ["Alice", "30", "Wonderland"],
-    ["Bob", "25", "Builderland"],
-  ]
-  let csv = CSV::from_array(data, has_header=false, generate_headers=true)
-  inspect!(csv.headers, content="[\"column1\", \"column2\", \"column3\"]")
-  inspect!(
-    csv.rows,
-    content="[[\"Alice\", \"30\", \"Wonderland\"], [\"Bob\", \"25\", \"Builderland\"]]",
-  )
-}
-
-///|
-test "CSV::from_array/first_row_empty_with_header" {
-  // 测试把空行当作表头的情况
-  let data : Array[Array[String]] = [[], []]
-  let csv = CSV::from_array(data, has_header=false)
-  // 表头应该为空
-  inspect!(csv.headers, content="[]")
-  // 数据行应该只包含第二行
-  inspect!(csv.rows, content="[[], []]")
-}
-
-///|
-test "CSV::from_array/empty_data_with_generate_headers" {
-  // 测试完全空的数组，但设置 generate_headers=true
-  let data : Array[Array[String]] = []
-  let csv = CSV::from_array(data, has_header=false, generate_headers=true)
-
-  // 由于数据完全为空，column_count=0，所以应该生成空的头
-  inspect!(csv.headers, content="[]")
-  inspect!(csv.rows, content="[]")
-}
-
-///|
-test "CSV::from_array/first_row_empty" {
-  // 测试第一行为空数组的情况
-  let data : Array[Array[String]] = [
-    [], // 第一行为空
-    ["Some", "Data", "Here"],
-  ]
-  let csv = CSV::from_array(data, has_header=false, generate_headers=true)
-
-  // 由于第一行为空，所以column_count=0，不应该生成任何头
-  inspect!(csv.headers, content="[]")
-  // 但行数据应该保留
-  inspect!(csv.rows, content="[[], [\"Some\", \"Data\", \"Here\"]]")
-}
-
-///|
-test "CSV::from_array/first_row_empty_with_header" {
-  // 测试把空行当作表头的情况
-  let data : Array[Array[String]] = [
-    [], // 空表头行
-    ["Some", "Data", "Here"],
-  ]
-  let csv = CSV::from_array(data, has_header=false, generate_headers=false)
-
-  // 表头应该为空
-  inspect!(csv.headers, content="[]")
-  // 数据行应该只包含第二行
-  inspect!(csv.rows, content="[[], [\"Some\", \"Data\", \"Here\"]]")
 }
 
 ///|

--- a/src/nyacsv.mbt
+++ b/src/nyacsv.mbt
@@ -13,12 +13,12 @@ struct CSV {
   rows : Array[Array[String]]
 }
 
-///|
+///| header of the CSV.
 pub fn CSV::header(self : CSV) -> Array[String] {
   self.headers
 }
 
-///|
+///| data of the CSV.
 pub fn CSV::data(self : CSV) -> Array[Array[String]] {
   self.rows
 }
@@ -198,13 +198,6 @@ pub fn CSV::new() -> CSV {
 }
 
 ///|
-test "CSV::new/basic" {
-  let csv = CSV::new()
-  inspect!(csv.headers, content="[]")
-  inspect!(csv.rows, content="[]")
-}
-
-///|
 pub fn CSV::from_array(
   data : Array[Array[String]],
   has_header~ : Bool = true,
@@ -261,136 +254,6 @@ pub fn CSV::parse_string(
 }
 
 ///|
-test "CSV::parse_string/basic_with_quoted_field" {
-  let data = "first,last,address,city,zip\nJohn,Doe,120 any st.,\"Anytown, WW\",08123"
-  let csv = CSV::parse_string(data)
-  inspect!(
-    csv.headers,
-    content="[\"first\", \"last\", \"address\", \"city\", \"zip\"]",
-  )
-  inspect!(
-    csv.rows,
-    content="[[\"John\", \"Doe\", \"120 any st.\", \"Anytown, WW\", \"08123\"]]",
-  )
-
-  // 验证引号字段正确解析
-  assert_eq!(csv.rows[0][3], "Anytown, WW")
-}
-
-///|
-test "CSV::parse_string/crlf_with_empty_fields" {
-  let data = "a,b,c\r\n1,\"\",\"\"\r\n2,3,4"
-  let csv = CSV::parse_string(data)
-  inspect!(csv.headers, content="[\"a\", \"b\", \"c\"]")
-  inspect!(csv.rows, content="[[\"1\", \"\", \"\"], [\"2\", \"3\", \"4\"]]")
-
-  // 验证空引号字段正确解析为空字符串
-  assert_eq!(csv.rows[0][1], "")
-  assert_eq!(csv.rows[0][2], "")
-}
-
-///|
-test "CSV::parse_string/quoted_with_internal_quotes" {
-  let data = "a,b\n1,\"ha \"\"ha\"\" ha\"\n3,4\n"
-  let csv = CSV::parse_string(data)
-  inspect!(csv.headers, content="[\"a\", \"b\"]")
-  inspect!(csv.rows, content="[[\"1\", \"ha \\\"ha\\\" ha\"], [\"3\", \"4\"]]")
-
-  // 验证内部引号正确处理
-  assert_eq!(csv.rows[0][1], "ha \"ha\" ha")
-}
-
-///|
-test "CSV::parse_string/quoted_with_internal_quotes" {
-  let data = "a,b\n1,\"ha \"\"ha\"\" ha\"\n3,4\n"
-  let csv = CSV::parse_string(data)
-  inspect!(csv.headers, content="[\"a\", \"b\"]")
-  inspect!(csv.rows, content="[[\"1\", \"ha \\\"ha\\\" ha\"], [\"3\", \"4\"]]")
-
-  // 验证内部引号正确处理
-  assert_eq!(csv.rows[0][1], "ha \"ha\" ha")
-}
-
-///|
-test "CSV::parse_string/json_in_field" {
-  let data = "key,val\n1,\"{\"\"type\"\": \"\"Point\"\", \"\"coordinates\"\": [102.0, 0.5]}\"\n"
-  let csv = CSV::parse_string(data)
-  inspect!(csv.headers, content="[\"key\", \"val\"]")
-  // 验证JSON字符串被正确解析
-  assert_eq!(
-    csv.rows[0][1],
-    "{\"type\": \"Point\", \"coordinates\": [102.0, 0.5]}",
-  )
-}
-
-///|
-test "CSV::parse_string/special_characters" {
-  let data = "Contact Phone Number,Location Coordinates,Cities,Counties\n2095257564,37�36'37.8\"N 121�2'17.9\"W,Modesto,Stanislaus"
-  let csv = CSV::parse_string(data)
-  inspect!(
-    csv.headers,
-    content="[\"Contact Phone Number\", \"Location Coordinates\", \"Cities\", \"Counties\"]",
-  )
-  // 验证特殊字符被正确处理
-  assert_eq!(csv.rows[0][1], "37�36'37.8\"N 121�2'17.9\"W")
-}
-
-///|
-test "CSV::parse_string/multiline_fields_crlf" {
-  let data = "a,b,c\r\n1,2,3\r\n\"Once upon \r\na time\",5,6\r\n7,8,9\r\n"
-  let csv = CSV::parse_string(data)
-  inspect!(csv.headers, content="[\"a\", \"b\", \"c\"]")
-  // 验证多行字段正确处理
-  assert_eq!(csv.rows[1][0], "Once upon \r\na time")
-}
-
-///|
-test "CSV::parse_string/multiline_fields_lf" {
-  let data = "a,b,c\n1,2,3\n\"Once upon \na time\",5,6\n7,8,9\n"
-  let csv = CSV::parse_string(data)
-  inspect!(csv.headers, content="[\"a\", \"b\", \"c\"]")
-
-  // 验证LF换行符的多行字段正确处理
-  assert_eq!(csv.rows[1][0], "Once upon \na time")
-}
-
-///|
-test "CSV::parse_string/simple_crlf" {
-  let data = "a,b,c\r\n1,2,3\r\n"
-  let csv = CSV::parse_string(data)
-  inspect!(csv.headers, content="[\"a\", \"b\", \"c\"]")
-  inspect!(csv.rows, content="[[\"1\", \"2\", \"3\"]]")
-}
-
-///|
-test "CSV::parse_string/unicode_characters" {
-  let data = "a,b,c\n1,2,3\n4,5,ʤ"
-  let csv = CSV::parse_string(data)
-  inspect!(csv.headers, content="[\"a\", \"b\", \"c\"]")
-  inspect!(csv.rows, content="[[\"1\", \"2\", \"3\"], [\"4\", \"5\", \"ʤ\"]]")
-
-  // 验证Unicode字符正确处理
-  assert_eq!(csv.rows[1][2], "ʤ")
-}
-
-///|
-test "CSV::parse_string/custom_delimiter" {
-  let data = "first;last;address\nJohn;Doe;\"120 any st., Anytown\""
-  let csv = CSV::parse_string(data, options={
-    delimiter: ';',
-    allow_newlines_in_quotes: true,
-    quote_char: '"',
-    skip_empty_lines: true,
-    trim_spaces: false,
-  })
-  inspect!(csv.headers, content="[\"first\", \"last\", \"address\"]")
-  inspect!(csv.rows, content="[[\"John\", \"Doe\", \"120 any st., Anytown\"]]")
-
-  // 验证自定义分隔符正确工作
-  assert_eq!(csv.rows[0][2], "120 any st., Anytown")
-}
-
-///|
 /// Parses a buffer containing CSV data into a structured CSV object.
 ///
 /// Parameters:
@@ -442,7 +305,7 @@ pub fn CSV::parse_buffer(
 ///
 /// Returns a `CSV` object containing the parsed data, with headers from the
 /// first row and subsequent rows as data.
-fn CSV::parse_bytes(
+pub fn CSV::parse_bytes(
   data : Bytes,
   options~ : CSVOptions = {
     delimiter: ',',

--- a/src/nyacsv_test.mbt
+++ b/src/nyacsv_test.mbt
@@ -138,7 +138,10 @@ test "CSV::parse_string/quoted_with_internal_quotes" {
   let data = "a,b\n1,\"ha \"\"ha\"\" ha\"\n3,4\n"
   let csv = CSV::parse_string(data)
   inspect!(csv.header(), content="[\"a\", \"b\"]")
-  inspect!(csv.data(), content="[[\"1\", \"ha \\\"ha\\\" ha\"], [\"3\", \"4\"]]")
+  inspect!(
+    csv.data(),
+    content="[[\"1\", \"ha \\\"ha\\\" ha\"], [\"3\", \"4\"]]",
+  )
 
   // 验证内部引号正确处理
   assert_eq!(csv.data()[0][1], "ha \"ha\" ha")
@@ -149,7 +152,10 @@ test "CSV::parse_string/quoted_with_internal_quotes" {
   let data = "a,b\n1,\"ha \"\"ha\"\" ha\"\n3,4\n"
   let csv = CSV::parse_string(data)
   inspect!(csv.header(), content="[\"a\", \"b\"]")
-  inspect!(csv.data(), content="[[\"1\", \"ha \\\"ha\\\" ha\"], [\"3\", \"4\"]]")
+  inspect!(
+    csv.data(),
+    content="[[\"1\", \"ha \\\"ha\\\" ha\"], [\"3\", \"4\"]]",
+  )
 
   // 验证内部引号正确处理
   assert_eq!(csv.data()[0][1], "ha \"ha\" ha")
@@ -211,7 +217,10 @@ test "CSV::parse_string/unicode_characters" {
   let data = "a,b,c\n1,2,3\n4,5,ʤ"
   let csv = CSV::parse_string(data)
   inspect!(csv.header(), content="[\"a\", \"b\", \"c\"]")
-  inspect!(csv.data(), content="[[\"1\", \"2\", \"3\"], [\"4\", \"5\", \"ʤ\"]]")
+  inspect!(
+    csv.data(),
+    content="[[\"1\", \"2\", \"3\"], [\"4\", \"5\", \"ʤ\"]]",
+  )
 
   // 验证Unicode字符正确处理
   assert_eq!(csv.data()[1][2], "ʤ")
@@ -220,7 +229,7 @@ test "CSV::parse_string/unicode_characters" {
 ///|
 test "CSV::parse_string/custom_delimiter" {
   let data = "first;last;address\nJohn;Doe;\"120 any st., Anytown\""
-  let csv = CSV::parse_string(data, options= CSVOptions::{
+  let csv = CSV::parse_string(data, options=CSVOptions::{
     delimiter: ';',
     allow_newlines_in_quotes: true,
     quote_char: '"',
@@ -228,7 +237,10 @@ test "CSV::parse_string/custom_delimiter" {
     trim_spaces: false,
   })
   inspect!(csv.header(), content="[\"first\", \"last\", \"address\"]")
-  inspect!(csv.data(), content="[[\"John\", \"Doe\", \"120 any st., Anytown\"]]")
+  inspect!(
+    csv.data(),
+    content="[[\"John\", \"Doe\", \"120 any st., Anytown\"]]",
+  )
 
   // 验证自定义分隔符正确工作
   assert_eq!(csv.data()[0][2], "120 any st., Anytown")

--- a/src/nyacsv_test.mbt
+++ b/src/nyacsv_test.mbt
@@ -1,0 +1,235 @@
+///|
+test "CSV::output/empty_csv" {
+  let csv = CSV::new()
+  let logger = @buffer.new()
+  println(csv)
+  inspect!(logger.contents().to_unchecked_string(), content="<Empty CSV>")
+}
+
+///|
+test "CSV::to_string/empty" {
+  let csv = CSV::new()
+  inspect!(csv.to_string(), content="\n")
+}
+
+///|
+test "CSV::from_array/empty_data" {
+  let data : Array[Array[String]] = []
+  let csv = CSV::from_array(data)
+  inspect!(csv.header(), content="[]")
+  inspect!(csv.data(), content="[]")
+}
+
+///|
+test "CSV::from_array/header_present" {
+  let data : Array[Array[String]] = [
+    ["Name", "Age", "City"],
+    ["Alice", "30", "Wonderland"],
+  ]
+  let csv = CSV::from_array(data)
+  inspect!(csv.header(), content="[\"Name\", \"Age\", \"City\"]")
+  inspect!(csv.data(), content="[[\"Alice\", \"30\", \"Wonderland\"]]")
+}
+
+///|
+test "CSV::from_array/generate_headers" {
+  let data : Array[Array[String]] = [
+    ["Alice", "30", "Wonderland"],
+    ["Bob", "25", "Builderland"],
+  ]
+  let csv = CSV::from_array(data, has_header=false, generate_headers=true)
+  inspect!(csv.header(), content="[\"column1\", \"column2\", \"column3\"]")
+  inspect!(
+    csv.data(),
+    content="[[\"Alice\", \"30\", \"Wonderland\"], [\"Bob\", \"25\", \"Builderland\"]]",
+  )
+}
+
+///|
+test "CSV::from_array/first_row_empty_with_header" {
+  // 测试把空行当作表头的情况
+  let data : Array[Array[String]] = [[], []]
+  let csv = CSV::from_array(data, has_header=false)
+  // 表头应该为空
+  inspect!(csv.header(), content="[]")
+  // 数据行应该只包含第二行
+  inspect!(csv.data(), content="[[], []]")
+}
+
+///|
+test "CSV::from_array/empty_data_with_generate_headers" {
+  // 测试完全空的数组，但设置 generate_headers=true
+  let data : Array[Array[String]] = []
+  let csv = CSV::from_array(data, has_header=false, generate_headers=true)
+
+  // 由于数据完全为空，column_count=0，所以应该生成空的头
+  inspect!(csv.header(), content="[]")
+  inspect!(csv.data(), content="[]")
+}
+
+///|
+test "CSV::from_array/first_row_empty" {
+  // 测试第一行为空数组的情况
+  let data : Array[Array[String]] = [
+    [], // 第一行为空
+    ["Some", "Data", "Here"],
+  ]
+  let csv = CSV::from_array(data, has_header=false, generate_headers=true)
+
+  // 由于第一行为空，所以column_count=0，不应该生成任何头
+  inspect!(csv.header(), content="[]")
+  // 但行数据应该保留
+  inspect!(csv.data(), content="[[], [\"Some\", \"Data\", \"Here\"]]")
+}
+
+///|
+test "CSV::from_array/first_row_empty_with_header" {
+  // 测试把空行当作表头的情况
+  let data : Array[Array[String]] = [
+    [], // 空表头行
+    ["Some", "Data", "Here"],
+  ]
+  let csv = CSV::from_array(data, has_header=false, generate_headers=false)
+
+  // 表头应该为空
+  inspect!(csv.header(), content="[]")
+  // 数据行应该只包含第二行
+  inspect!(csv.data(), content="[[], [\"Some\", \"Data\", \"Here\"]]")
+}
+
+///|
+test "CSV::new/basic" {
+  let csv = CSV::new()
+  inspect!(csv.header(), content="[]")
+  inspect!(csv.data(), content="[]")
+}
+
+///|
+test "CSV::parse_string/basic_with_quoted_field" {
+  let data = "first,last,address,city,zip\nJohn,Doe,120 any st.,\"Anytown, WW\",08123"
+  let csv = CSV::parse_string(data)
+  inspect!(
+    csv.header(),
+    content="[\"first\", \"last\", \"address\", \"city\", \"zip\"]",
+  )
+  inspect!(
+    csv.data(),
+    content="[[\"John\", \"Doe\", \"120 any st.\", \"Anytown, WW\", \"08123\"]]",
+  )
+
+  // 验证引号字段正确解析
+  assert_eq!(csv.data()[0][3], "Anytown, WW")
+}
+
+///|
+test "CSV::parse_string/crlf_with_empty_fields" {
+  let data = "a,b,c\r\n1,\"\",\"\"\r\n2,3,4"
+  let csv = CSV::parse_string(data)
+  inspect!(csv.header(), content="[\"a\", \"b\", \"c\"]")
+  inspect!(csv.data(), content="[[\"1\", \"\", \"\"], [\"2\", \"3\", \"4\"]]")
+
+  // 验证空引号字段正确解析为空字符串
+  assert_eq!(csv.data()[0][1], "")
+  assert_eq!(csv.data()[0][2], "")
+}
+
+///|
+test "CSV::parse_string/quoted_with_internal_quotes" {
+  let data = "a,b\n1,\"ha \"\"ha\"\" ha\"\n3,4\n"
+  let csv = CSV::parse_string(data)
+  inspect!(csv.header(), content="[\"a\", \"b\"]")
+  inspect!(csv.data(), content="[[\"1\", \"ha \\\"ha\\\" ha\"], [\"3\", \"4\"]]")
+
+  // 验证内部引号正确处理
+  assert_eq!(csv.data()[0][1], "ha \"ha\" ha")
+}
+
+///|
+test "CSV::parse_string/quoted_with_internal_quotes" {
+  let data = "a,b\n1,\"ha \"\"ha\"\" ha\"\n3,4\n"
+  let csv = CSV::parse_string(data)
+  inspect!(csv.header(), content="[\"a\", \"b\"]")
+  inspect!(csv.data(), content="[[\"1\", \"ha \\\"ha\\\" ha\"], [\"3\", \"4\"]]")
+
+  // 验证内部引号正确处理
+  assert_eq!(csv.data()[0][1], "ha \"ha\" ha")
+}
+
+///|
+test "CSV::parse_string/json_in_field" {
+  let data = "key,val\n1,\"{\"\"type\"\": \"\"Point\"\", \"\"coordinates\"\": [102.0, 0.5]}\"\n"
+  let csv = CSV::parse_string(data)
+  inspect!(csv.header(), content="[\"key\", \"val\"]")
+  // 验证JSON字符串被正确解析
+  assert_eq!(
+    csv.data()[0][1],
+    "{\"type\": \"Point\", \"coordinates\": [102.0, 0.5]}",
+  )
+}
+
+///|
+test "CSV::parse_string/special_characters" {
+  let data = "Contact Phone Number,Location Coordinates,Cities,Counties\n2095257564,37�36'37.8\"N 121�2'17.9\"W,Modesto,Stanislaus"
+  let csv = CSV::parse_string(data)
+  inspect!(
+    csv.header(),
+    content="[\"Contact Phone Number\", \"Location Coordinates\", \"Cities\", \"Counties\"]",
+  )
+  // 验证特殊字符被正确处理
+  assert_eq!(csv.data()[0][1], "37�36'37.8\"N 121�2'17.9\"W")
+}
+
+///|
+test "CSV::parse_string/multiline_fields_crlf" {
+  let data = "a,b,c\r\n1,2,3\r\n\"Once upon \r\na time\",5,6\r\n7,8,9\r\n"
+  let csv = CSV::parse_string(data)
+  inspect!(csv.header(), content="[\"a\", \"b\", \"c\"]")
+  // 验证多行字段正确处理
+  assert_eq!(csv.data()[1][0], "Once upon \r\na time")
+}
+
+///|
+test "CSV::parse_string/multiline_fields_lf" {
+  let data = "a,b,c\n1,2,3\n\"Once upon \na time\",5,6\n7,8,9\n"
+  let csv = CSV::parse_string(data)
+  inspect!(csv.header(), content="[\"a\", \"b\", \"c\"]")
+
+  // 验证LF换行符的多行字段正确处理
+  assert_eq!(csv.data()[1][0], "Once upon \na time")
+}
+
+///|
+test "CSV::parse_string/simple_crlf" {
+  let data = "a,b,c\r\n1,2,3\r\n"
+  let csv = CSV::parse_string(data)
+  inspect!(csv.header(), content="[\"a\", \"b\", \"c\"]")
+  inspect!(csv.data(), content="[[\"1\", \"2\", \"3\"]]")
+}
+
+///|
+test "CSV::parse_string/unicode_characters" {
+  let data = "a,b,c\n1,2,3\n4,5,ʤ"
+  let csv = CSV::parse_string(data)
+  inspect!(csv.header(), content="[\"a\", \"b\", \"c\"]")
+  inspect!(csv.data(), content="[[\"1\", \"2\", \"3\"], [\"4\", \"5\", \"ʤ\"]]")
+
+  // 验证Unicode字符正确处理
+  assert_eq!(csv.data()[1][2], "ʤ")
+}
+
+///|
+test "CSV::parse_string/custom_delimiter" {
+  let data = "first;last;address\nJohn;Doe;\"120 any st., Anytown\""
+  let csv = CSV::parse_string(data, options= CSVOptions::{
+    delimiter: ';',
+    allow_newlines_in_quotes: true,
+    quote_char: '"',
+    skip_empty_lines: true,
+    trim_spaces: false,
+  })
+  inspect!(csv.header(), content="[\"first\", \"last\", \"address\"]")
+  inspect!(csv.data(), content="[[\"John\", \"Doe\", \"120 any st., Anytown\"]]")
+
+  // 验证自定义分隔符正确工作
+  assert_eq!(csv.data()[0][2], "120 any st., Anytown")
+}

--- a/src/nyacsv_test.mbt
+++ b/src/nyacsv_test.mbt
@@ -2,7 +2,7 @@
 test "CSV::output/empty_csv" {
   let csv = CSV::new()
   let logger = @buffer.new()
-  println(csv)
+  csv.output(logger)
   inspect!(logger.contents().to_unchecked_string(), content="<Empty CSV>")
 }
 

--- a/src/parser.mbt
+++ b/src/parser.mbt
@@ -21,10 +21,10 @@ fn parse[T : CSVReader](
       if reader.peek_char() == Some('\n') {
         if in_quotes && options.allow_newlines_in_quotes {
           // 在引号内，需要同时处理 \r 和 \n
-          field.write_char(ch)  // 写入 \r
-          reader.read_char() |> ignore  // 消费 \n
-          field.write_char('\n')  // 写入 \n
-          continue  // 继续下一轮循环
+          field.write_char(ch) // 写入 \r
+          reader.read_char() |> ignore // 消费 \n
+          field.write_char('\n') // 写入 \n
+          continue // 继续下一轮循环
         } else {
           // 不在引号内，跳过 \r，之后将处理 \n
           continue

--- a/src/reader.mbt
+++ b/src/reader.mbt
@@ -14,7 +14,7 @@
 /// * `trim_spaces` : Boolean flag indicating whether leading and trailing
 /// whitespace should be removed from fields.
 ///
-pub struct CSVOptions {
+pub(all) struct CSVOptions {
   delimiter : Char
   allow_newlines_in_quotes : Bool
   quote_char : Char


### PR DESCRIPTION
feat: add CSV::header() & data() to allow to access data in `CSV` 
fix: fix bug casue by CSVOptions `read-only` error, it will cause uer can not create `CSVOptions`
fmt: update moon fmt
create: split test to individual `nyacsv_test.mbt` file. To follow Development criteria