### PR TITLE
fix: resolve all compiler warnings and errors

### DIFF
--- a/src/NyaCSV.mbti
+++ b/src/NyaCSV.mbti
@@ -1,3 +1,4 @@
+// Generated using `moon info`, DON'T EDIT IT
 package "xunyoyo/NyaCSV"
 
 import(
@@ -6,18 +7,18 @@ import(
 
 // Values
 
+// Errors
+
 // Types and methods
 type CSV
-impl CSV {
-  data(Self) -> Array[Array[String]]
-  from_array(Array[Array[String]], has_header~ : Bool = .., generate_headers~ : Bool = ..) -> Self
-  header(Self) -> Array[String]
-  new() -> Self
-  parse_buffer(@buffer.T, options~ : CSVOptions = ..) -> Self
-  parse_bytes(Bytes, options~ : CSVOptions = ..) -> Self
-  parse_string(String, options~ : CSVOptions = ..) -> Self
-  shape(Self) -> (Int, Int)
-}
+fn CSV::data(Self) -> Array[Array[String]]
+fn CSV::from_array(Array[Array[String]], has_header? : Bool, generate_headers? : Bool) -> Self
+fn CSV::header(Self) -> Array[String]
+fn CSV::new() -> Self
+fn CSV::parse_buffer(@buffer.T, options? : CSVOptions) -> Self
+fn CSV::parse_bytes(Bytes, options? : CSVOptions) -> Self
+fn CSV::parse_string(String, options? : CSVOptions) -> Self
+fn CSV::shape(Self) -> (Int, Int)
 impl Show for CSV
 
 pub(all) struct CSVOptions {

--- a/src/nyacsv.mbt
+++ b/src/nyacsv.mbt
@@ -54,10 +54,10 @@ pub impl Show for CSV with output(self, logger) -> Unit {
 
     // 计算所有行的最大宽度，并替换换行符
     for row in self.rows {
-      for i in 0..<@math.minimum(row.length(), self.headers.length()) {
+      for i in 0..<@cmp.minimum(row.length(), self.headers.length()) {
         // 处理字段中的换行符，计算适当的宽度
         let processed_value = row[i].replace(old="\n", new="\\n")
-        column_widths[i] = @math.maximum(
+        column_widths[i] = @cmp.maximum(
           column_widths[i],
           processed_value.length(),
         )
@@ -324,7 +324,7 @@ pub fn CSV::parse_bytes(
 
 ///|
 test "CSV::parse_bytes/basic_csv" {
-  let data = Bytes::of_string("header1,header2\nvalue1,value2")
+  let data = "header1,header2\nvalue1,value2".to_bytes()
   let csv = CSV::parse_bytes(data)
   inspect(csv.header(), content="[\"header1\", \"header2\"]")
   inspect(csv.data(), content="[[\"value1\", \"value2\"]]")

--- a/src/nyacsv.mbt
+++ b/src/nyacsv.mbt
@@ -118,7 +118,7 @@ test "CSV::output/single_row_no_newline" {
     #|| Alice | 30  | Wonderland |
     #|+-------+-----+------------+
     #|
-  inspect!(logger.contents().to_unchecked_string(), content=expected)
+  inspect(logger.contents().to_unchecked_string(), content=expected)
 }
 
 ///|
@@ -138,7 +138,7 @@ test "CSV::output/row_with_missing_fields" {
     #|| Bob   | 25  |            |         |
     #|+-------+-----+------------+---------+
     #|
-  inspect!(logger.contents().to_unchecked_string(), content=expected)
+  inspect(logger.contents().to_unchecked_string(), content=expected)
 }
 
 ///|
@@ -160,7 +160,7 @@ pub impl Show for CSV with to_string(self) -> String {
 ///|
 test "CSV::to_string/single_header_no_rows" {
   let csv = { headers: ["Name"], rows: [] }
-  inspect!(csv.to_string(), content="Name\n")
+  inspect(csv.to_string(), content="Name\n")
 }
 
 ///|
@@ -174,7 +174,7 @@ test "CSV::to_string/headers_and_rows" {
     #|John,25,New York
     #|Jane,30,San Francisco
     #|
-  inspect!(csv.to_string(), content=expected)
+  inspect(csv.to_string(), content=expected)
 }
 
 ///|
@@ -192,7 +192,7 @@ pub fn CSV::new() -> CSV {
 pub fn CSV::from_array(
   data : Array[Array[String]],
   has_header~ : Bool = true,
-  generate_headers~ : Bool = true
+  generate_headers~ : Bool = true,
 ) -> CSV {
   if data.is_empty() {
     CSV::new()
@@ -238,7 +238,7 @@ pub fn CSV::parse_string(
     quote_char: '"',
     skip_empty_lines: true,
     trim_spaces: false,
-  }
+  },
 ) -> CSV {
   let reader : StringReader = { source: data, pos: 0 }
   CSV::from_array(parse(reader, options~))
@@ -249,8 +249,8 @@ test "CSV::parse_buffer/basic" {
   let buffer = @buffer.new()
   buffer.write_string("header1,header2\nvalue1,value2")
   let csv = CSV::parse_buffer(buffer)
-  inspect!(csv.header(), content="[\"header1\", \"header2\"]")
-  inspect!(csv.data(), content="[[\"value1\", \"value2\"]]")
+  inspect(csv.header(), content="[\"header1\", \"header2\"]")
+  inspect(csv.data(), content="[[\"value1\", \"value2\"]]")
 }
 
 ///|
@@ -280,7 +280,7 @@ pub fn CSV::parse_buffer(
     quote_char: '"',
     skip_empty_lines: true,
     trim_spaces: false,
-  }
+  },
 ) -> CSV {
   let reader : StringReader = {
     source: data.contents().to_unchecked_string(),
@@ -316,7 +316,7 @@ pub fn CSV::parse_bytes(
     quote_char: '"',
     skip_empty_lines: true,
     trim_spaces: false,
-  }
+  },
 ) -> CSV {
   let reader : StringReader = { source: data.to_unchecked_string(), pos: 0 }
   CSV::from_array(parse(reader, options~))
@@ -326,6 +326,6 @@ pub fn CSV::parse_bytes(
 test "CSV::parse_bytes/basic_csv" {
   let data = Bytes::of_string("header1,header2\nvalue1,value2")
   let csv = CSV::parse_bytes(data)
-  inspect!(csv.header(), content="[\"header1\", \"header2\"]")
-  inspect!(csv.data(), content="[[\"value1\", \"value2\"]]")
+  inspect(csv.header(), content="[\"header1\", \"header2\"]")
+  inspect(csv.data(), content="[[\"value1\", \"value2\"]]")
 }

--- a/src/nyacsv_test.mbt
+++ b/src/nyacsv_test.mbt
@@ -246,7 +246,7 @@ test "@nyacsv.CSV::parse_bytes/empty_bytes" {
 ///| Test for a single line of data with no header.
 test "@nyacsv.CSV::parse_bytes/single_line_no_header" {
   // Create a byte sequence representing a single line of data values separated by commas.
-  let data = Bytes::of_string("value1,value2,value3")
+  let data = "value1,value2,value3".to_bytes()
   // Call the `parse_bytes` function with no header present in the data.
   let csv = @NyaCSV.CSV::parse_bytes(data, options={
     delimiter: ',',

--- a/src/nyacsv_test.mbt
+++ b/src/nyacsv_test.mbt
@@ -3,21 +3,21 @@ test "CSV::output/empty_csv" {
   let csv = CSV::new()
   let logger = @buffer.new()
   csv.output(logger)
-  inspect!(logger.contents().to_unchecked_string(), content="<Empty CSV>")
+  inspect(logger.contents().to_unchecked_string(), content="<Empty CSV>")
 }
 
 ///|
 test "CSV::to_string/empty" {
   let csv = CSV::new()
-  inspect!(csv.to_string(), content="\n")
+  inspect(csv.to_string(), content="\n")
 }
 
 ///|
 test "CSV::from_array/empty_data" {
   let data : Array[Array[String]] = []
   let csv = CSV::from_array(data)
-  inspect!(csv.header(), content="[]")
-  inspect!(csv.data(), content="[]")
+  inspect(csv.header(), content="[]")
+  inspect(csv.data(), content="[]")
 }
 
 ///|
@@ -27,8 +27,8 @@ test "CSV::from_array/header_present" {
     ["Alice", "30", "Wonderland"],
   ]
   let csv = CSV::from_array(data)
-  inspect!(csv.header(), content="[\"Name\", \"Age\", \"City\"]")
-  inspect!(csv.data(), content="[[\"Alice\", \"30\", \"Wonderland\"]]")
+  inspect(csv.header(), content="[\"Name\", \"Age\", \"City\"]")
+  inspect(csv.data(), content="[[\"Alice\", \"30\", \"Wonderland\"]]")
 }
 
 ///|
@@ -38,8 +38,8 @@ test "CSV::from_array/generate_headers" {
     ["Bob", "25", "Builderland"],
   ]
   let csv = CSV::from_array(data, has_header=false, generate_headers=true)
-  inspect!(csv.header(), content="[\"column1\", \"column2\", \"column3\"]")
-  inspect!(
+  inspect(csv.header(), content="[\"column1\", \"column2\", \"column3\"]")
+  inspect(
     csv.data(),
     content="[[\"Alice\", \"30\", \"Wonderland\"], [\"Bob\", \"25\", \"Builderland\"]]",
   )
@@ -51,9 +51,9 @@ test "CSV::from_array/first_row_empty_with_header" {
   let data : Array[Array[String]] = [[], []]
   let csv = CSV::from_array(data, has_header=false)
   // 表头应该为空
-  inspect!(csv.header(), content="[]")
+  inspect(csv.header(), content="[]")
   // 数据行应该只包含第二行
-  inspect!(csv.data(), content="[[], []]")
+  inspect(csv.data(), content="[[], []]")
 }
 
 ///|
@@ -63,8 +63,8 @@ test "CSV::from_array/empty_data_with_generate_headers" {
   let csv = CSV::from_array(data, has_header=false, generate_headers=true)
 
   // 由于数据完全为空，column_count=0，所以应该生成空的头
-  inspect!(csv.header(), content="[]")
-  inspect!(csv.data(), content="[]")
+  inspect(csv.header(), content="[]")
+  inspect(csv.data(), content="[]")
 }
 
 ///|
@@ -77,9 +77,9 @@ test "CSV::from_array/first_row_empty" {
   let csv = CSV::from_array(data, has_header=false, generate_headers=true)
 
   // 由于第一行为空，所以column_count=0，不应该生成任何头
-  inspect!(csv.header(), content="[]")
+  inspect(csv.header(), content="[]")
   // 但行数据应该保留
-  inspect!(csv.data(), content="[[], [\"Some\", \"Data\", \"Here\"]]")
+  inspect(csv.data(), content="[[], [\"Some\", \"Data\", \"Here\"]]")
 }
 
 ///|
@@ -92,82 +92,76 @@ test "CSV::from_array/first_row_empty_with_header" {
   let csv = CSV::from_array(data, has_header=false, generate_headers=false)
 
   // 表头应该为空
-  inspect!(csv.header(), content="[]")
+  inspect(csv.header(), content="[]")
   // 数据行应该只包含第二行
-  inspect!(csv.data(), content="[[], [\"Some\", \"Data\", \"Here\"]]")
+  inspect(csv.data(), content="[[], [\"Some\", \"Data\", \"Here\"]]")
 }
 
 ///|
 test "CSV::new/basic" {
   let csv = CSV::new()
-  inspect!(csv.header(), content="[]")
-  inspect!(csv.data(), content="[]")
+  inspect(csv.header(), content="[]")
+  inspect(csv.data(), content="[]")
 }
 
 ///|
 test "CSV::parse_string/basic_with_quoted_field" {
   let data = "first,last,address,city,zip\nJohn,Doe,120 any st.,\"Anytown, WW\",08123"
   let csv = CSV::parse_string(data)
-  inspect!(
+  inspect(
     csv.header(),
     content="[\"first\", \"last\", \"address\", \"city\", \"zip\"]",
   )
-  inspect!(
+  inspect(
     csv.data(),
     content="[[\"John\", \"Doe\", \"120 any st.\", \"Anytown, WW\", \"08123\"]]",
   )
 
   // 验证引号字段正确解析
-  assert_eq!(csv.data()[0][3], "Anytown, WW")
+  assert_eq(csv.data()[0][3], "Anytown, WW")
 }
 
 ///|
 test "CSV::parse_string/crlf_with_empty_fields" {
   let data = "a,b,c\r\n1,\"\",\"\"\r\n2,3,4"
   let csv = CSV::parse_string(data)
-  inspect!(csv.header(), content="[\"a\", \"b\", \"c\"]")
-  inspect!(csv.data(), content="[[\"1\", \"\", \"\"], [\"2\", \"3\", \"4\"]]")
+  inspect(csv.header(), content="[\"a\", \"b\", \"c\"]")
+  inspect(csv.data(), content="[[\"1\", \"\", \"\"], [\"2\", \"3\", \"4\"]]")
 
   // 验证空引号字段正确解析为空字符串
-  assert_eq!(csv.data()[0][1], "")
-  assert_eq!(csv.data()[0][2], "")
+  assert_eq(csv.data()[0][1], "")
+  assert_eq(csv.data()[0][2], "")
 }
 
 ///|
 test "CSV::parse_string/quoted_with_internal_quotes" {
   let data = "a,b\n1,\"ha \"\"ha\"\" ha\"\n3,4\n"
   let csv = CSV::parse_string(data)
-  inspect!(csv.header(), content="[\"a\", \"b\"]")
-  inspect!(
-    csv.data(),
-    content="[[\"1\", \"ha \\\"ha\\\" ha\"], [\"3\", \"4\"]]",
-  )
+  inspect(csv.header(), content="[\"a\", \"b\"]")
+  inspect(csv.data(), content="[[\"1\", \"ha \\\"ha\\\" ha\"], [\"3\", \"4\"]]")
 
   // 验证内部引号正确处理
-  assert_eq!(csv.data()[0][1], "ha \"ha\" ha")
+  assert_eq(csv.data()[0][1], "ha \"ha\" ha")
 }
 
 ///|
 test "CSV::parse_string/quoted_with_internal_quotes" {
   let data = "a,b\n1,\"ha \"\"ha\"\" ha\"\n3,4\n"
   let csv = CSV::parse_string(data)
-  inspect!(csv.header(), content="[\"a\", \"b\"]")
-  inspect!(
-    csv.data(),
-    content="[[\"1\", \"ha \\\"ha\\\" ha\"], [\"3\", \"4\"]]",
-  )
+  inspect(csv.header(), content="[\"a\", \"b\"]")
+  inspect(csv.data(), content="[[\"1\", \"ha \\\"ha\\\" ha\"], [\"3\", \"4\"]]")
 
   // 验证内部引号正确处理
-  assert_eq!(csv.data()[0][1], "ha \"ha\" ha")
+  assert_eq(csv.data()[0][1], "ha \"ha\" ha")
 }
 
 ///|
 test "CSV::parse_string/json_in_field" {
   let data = "key,val\n1,\"{\"\"type\"\": \"\"Point\"\", \"\"coordinates\"\": [102.0, 0.5]}\"\n"
   let csv = CSV::parse_string(data)
-  inspect!(csv.header(), content="[\"key\", \"val\"]")
+  inspect(csv.header(), content="[\"key\", \"val\"]")
   // 验证JSON字符串被正确解析
-  assert_eq!(
+  assert_eq(
     csv.data()[0][1],
     "{\"type\": \"Point\", \"coordinates\": [102.0, 0.5]}",
   )
@@ -177,53 +171,50 @@ test "CSV::parse_string/json_in_field" {
 test "CSV::parse_string/special_characters" {
   let data = "Contact Phone Number,Location Coordinates,Cities,Counties\n2095257564,37�36'37.8\"N 121�2'17.9\"W,Modesto,Stanislaus"
   let csv = CSV::parse_string(data)
-  inspect!(
+  inspect(
     csv.header(),
     content="[\"Contact Phone Number\", \"Location Coordinates\", \"Cities\", \"Counties\"]",
   )
   // 验证特殊字符被正确处理
-  assert_eq!(csv.data()[0][1], "37�36'37.8\"N 121�2'17.9\"W")
+  assert_eq(csv.data()[0][1], "37�36'37.8\"N 121�2'17.9\"W")
 }
 
 ///|
 test "CSV::parse_string/multiline_fields_crlf" {
   let data = "a,b,c\r\n1,2,3\r\n\"Once upon \r\na time\",5,6\r\n7,8,9\r\n"
   let csv = CSV::parse_string(data)
-  inspect!(csv.header(), content="[\"a\", \"b\", \"c\"]")
+  inspect(csv.header(), content="[\"a\", \"b\", \"c\"]")
   // 验证多行字段正确处理
-  assert_eq!(csv.data()[1][0], "Once upon \r\na time")
+  assert_eq(csv.data()[1][0], "Once upon \r\na time")
 }
 
 ///|
 test "CSV::parse_string/multiline_fields_lf" {
   let data = "a,b,c\n1,2,3\n\"Once upon \na time\",5,6\n7,8,9\n"
   let csv = CSV::parse_string(data)
-  inspect!(csv.header(), content="[\"a\", \"b\", \"c\"]")
+  inspect(csv.header(), content="[\"a\", \"b\", \"c\"]")
 
   // 验证LF换行符的多行字段正确处理
-  assert_eq!(csv.data()[1][0], "Once upon \na time")
+  assert_eq(csv.data()[1][0], "Once upon \na time")
 }
 
 ///|
 test "CSV::parse_string/simple_crlf" {
   let data = "a,b,c\r\n1,2,3\r\n"
   let csv = CSV::parse_string(data)
-  inspect!(csv.header(), content="[\"a\", \"b\", \"c\"]")
-  inspect!(csv.data(), content="[[\"1\", \"2\", \"3\"]]")
+  inspect(csv.header(), content="[\"a\", \"b\", \"c\"]")
+  inspect(csv.data(), content="[[\"1\", \"2\", \"3\"]]")
 }
 
 ///|
 test "CSV::parse_string/unicode_characters" {
   let data = "a,b,c\n1,2,3\n4,5,ʤ"
   let csv = CSV::parse_string(data)
-  inspect!(csv.header(), content="[\"a\", \"b\", \"c\"]")
-  inspect!(
-    csv.data(),
-    content="[[\"1\", \"2\", \"3\"], [\"4\", \"5\", \"ʤ\"]]",
-  )
+  inspect(csv.header(), content="[\"a\", \"b\", \"c\"]")
+  inspect(csv.data(), content="[[\"1\", \"2\", \"3\"], [\"4\", \"5\", \"ʤ\"]]")
 
   // 验证Unicode字符正确处理
-  assert_eq!(csv.data()[1][2], "ʤ")
+  assert_eq(csv.data()[1][2], "ʤ")
 }
 
 ///|
@@ -236,14 +227,11 @@ test "CSV::parse_string/custom_delimiter" {
     skip_empty_lines: true,
     trim_spaces: false,
   })
-  inspect!(csv.header(), content="[\"first\", \"last\", \"address\"]")
-  inspect!(
-    csv.data(),
-    content="[[\"John\", \"Doe\", \"120 any st., Anytown\"]]",
-  )
+  inspect(csv.header(), content="[\"first\", \"last\", \"address\"]")
+  inspect(csv.data(), content="[[\"John\", \"Doe\", \"120 any st., Anytown\"]]")
 
   // 验证自定义分隔符正确工作
-  assert_eq!(csv.data()[0][2], "120 any st., Anytown")
+  assert_eq(csv.data()[0][2], "120 any st., Anytown")
 }
 
 ///| Test for empty bytes input.
@@ -251,8 +239,8 @@ test "@nyacsv.CSV::parse_bytes/empty_bytes" {
   let data = Bytes::new(0) // Create an empty byte sequence.
   let csv = @NyaCSV.CSV::parse_bytes(data) // Call the `parse_bytes` function with empty data.
   // Check if the parsed CSV has no headers and no data rows.
-  inspect!(csv.header(), content="[]")
-  inspect!(csv.data(), content="[]")
+  inspect(csv.header(), content="[]")
+  inspect(csv.data(), content="[]")
 }
 
 ///| Test for a single line of data with no header.
@@ -269,5 +257,5 @@ test "@nyacsv.CSV::parse_bytes/single_line_no_header" {
   })
 
   // Check if the parsed CSV has expected data values with an implicit header.
-  inspect!(csv.header(), content="[\"value1\", \"value2\", \"value3\"]")
+  inspect(csv.header(), content="[\"value1\", \"value2\", \"value3\"]")
 }

--- a/src/parser.mbt
+++ b/src/parser.mbt
@@ -1,5 +1,5 @@
 ///|
-fn parse[T : CSVReader](
+fn[T : CSVReader] parse(
   reader : T,
   options~ : CSVOptions = {
     delimiter: ',',
@@ -7,7 +7,7 @@ fn parse[T : CSVReader](
     quote_char: '"',
     skip_empty_lines: true,
     trim_spaces: false,
-  }
+  },
 ) -> Array[Array[String]] {
   let rows : Array[Array[String]] = Array::new()
   let mut row = Array::make(0, "")
@@ -151,8 +151,8 @@ test "CSV::parse_string/carriage_return_in_quotes_not_allowed" {
   })
 
   // 验证引号在遇到\r时被强制结束，并创建了新行
-  inspect!(csv.rows.length(), content="3") // 应该分成多行
-  assert_eq!(csv.rows[0][1], "line")
+  inspect(csv.rows.length(), content="3") // 应该分成多行
+  assert_eq(csv.rows[0][1], "line")
   // 后面的行会因为强制结束引号而成为新行的一部分
 }
 
@@ -161,10 +161,10 @@ test "CSV::parse_string/carriage_return_in_quotes" {
   // 测试引号内的\r在允许引号内换行的情况下被保留
   let data = "a,b,c\n1,\"line\rwith\rCRs\",3 "
   let csv = CSV::parse_string(data)
-  inspect!(csv.headers, content="[\"a\", \"b\", \"c\"]")
+  inspect(csv.headers, content="[\"a\", \"b\", \"c\"]")
 
   // 验证引号内的\r被正确保留
-  assert_eq!(csv.rows[0][1], "line\rwith\rCRs")
+  assert_eq(csv.rows[0][1], "line\rwith\rCRs")
   // 123
 }
 

--- a/src/reader.mbt
+++ b/src/reader.mbt
@@ -38,7 +38,7 @@ priv struct StringReader {
 ///|
 impl CSVReader for StringReader with read_char(self) -> Char? {
   if self.pos < self.source.length() {
-    let ch = self.source[self.pos]
+    let ch = Int::unsafe_to_char(self.source[self.pos])
     self.pos += 1
     Some(ch)
   } else {
@@ -69,7 +69,7 @@ test "StringReader::read_char/past_end_of_string" {
 ///|
 impl CSVReader for StringReader with peek_char(self) -> Char? {
   if self.pos < self.source.length() {
-    Some(self.source[self.pos])
+    Some(Int::unsafe_to_char(self.source[self.pos]))
   } else {
     None
   }

--- a/src/reader.mbt
+++ b/src/reader.mbt
@@ -49,21 +49,21 @@ impl CSVReader for StringReader with read_char(self) -> Char? {
 ///|
 test "StringReader::read_char/normal_case" {
   let reader : StringReader = { source: "Hello, World!", pos: 0 }
-  inspect!(reader.read_char(), content="Some('H')")
-  inspect!(reader.read_char(), content="Some('e')")
-  inspect!(reader.read_char(), content="Some('l')")
+  inspect(reader.read_char(), content="Some('H')")
+  inspect(reader.read_char(), content="Some('e')")
+  inspect(reader.read_char(), content="Some('l')")
 }
 
 ///|
 test "StringReader::read_char/empty_string" {
   let reader : StringReader = { source: "", pos: 0 }
-  inspect!(reader.read_char(), content="None")
+  inspect(reader.read_char(), content="None")
 }
 
 ///|
 test "StringReader::read_char/past_end_of_string" {
   let reader : StringReader = { source: "Hello", pos: 5 } // 'pos' is set to the length of the string
-  inspect!(reader.read_char(), content="None")
+  inspect(reader.read_char(), content="None")
 }
 
 ///|
@@ -78,21 +78,21 @@ impl CSVReader for StringReader with peek_char(self) -> Char? {
 ///|
 test "StringReader::peek_char/normal_case" {
   let reader : StringReader = { source: "Hello, World!", pos: 0 }
-  inspect!(reader.peek_char(), content="Some('H')")
+  inspect(reader.peek_char(), content="Some('H')")
   reader.pos = 7
-  inspect!(reader.peek_char(), content="Some('W')")
+  inspect(reader.peek_char(), content="Some('W')")
 }
 
 ///|
 test "StringReader::peek_char/empty_string" {
   let reader : StringReader = { source: "", pos: 0 }
-  inspect!(reader.peek_char(), content="None")
+  inspect(reader.peek_char(), content="None")
 }
 
 ///|
 test "StringReader::peek_char/at_end_of_string" {
   let reader : StringReader = { source: "Hello", pos: 5 } // 'pos' is set to the length of the string
-  inspect!(reader.peek_char(), content="None")
+  inspect(reader.peek_char(), content="None")
 }
 
 ///|


### PR DESCRIPTION
> [!NOTE]
> This PR was made by an LLM agent.

- Fix type mismatch errors in reader.mbt by using Int::unsafe_to_char() for String indexing
- Replace deprecated @math.minimum with @cmp.minimum in nyacsv.mbt  
- Replace deprecated @math.maximum with @cmp.maximum in nyacsv.mbt
- Replace deprecated Bytes::of_string with str.to_bytes() in nyacsv.mbt and test files

All tests continue to pass after these fixes.