### PR TITLE
Fix MoonBit warning and test assertions

### DIFF
--- a/nyacsv.mbt
+++ b/nyacsv.mbt
@@ -288,8 +288,8 @@ test "CSV::parse_buffer/basic" {
     #|
   buffer.write_string(data)
   let csv = CSV::parse_buffer(buffer)
-  inspect(csv.header(), content="[\"header1\", \"header2\"]")
-  inspect(csv.data(), content="[[\"value1\", \"value2\"]]")
+  assert_true(csv.header() == ["header1", "header2"])
+  assert_true(csv.data() == [["value1", "value2"]])
 }
 
 ///|
@@ -370,6 +370,6 @@ test "CSV::parse_bytes/basic_csv" {
     #|
   let data = @encoding/utf8.encode(source)
   let csv = CSV::parse_bytes(data)
-  inspect(csv.header(), content="[\"header1\", \"header2\"]")
-  inspect(csv.data(), content="[[\"value1\", \"value2\"]]")
+  assert_true(csv.header() == ["header1", "header2"])
+  assert_true(csv.data() == [["value1", "value2"]])
 }

--- a/nyacsv_test.mbt
+++ b/nyacsv_test.mbt
@@ -16,8 +16,8 @@ test "CSV::to_string/empty" {
 test "CSV::from_array/empty_data" {
   let data : Array[Array[String]] = []
   let csv = CSV::from_array(data)
-  inspect(csv.header(), content="[]")
-  inspect(csv.data(), content="[]")
+  assert_true(csv.header() == [])
+  assert_true(csv.data() == [])
 }
 
 ///|
@@ -27,8 +27,8 @@ test "CSV::from_array/header_present" {
     ["Alice", "30", "Wonderland"],
   ]
   let csv = CSV::from_array(data)
-  inspect(csv.header(), content="[\"Name\", \"Age\", \"City\"]")
-  inspect(csv.data(), content="[[\"Alice\", \"30\", \"Wonderland\"]]")
+  assert_true(csv.header() == ["Name", "Age", "City"])
+  assert_true(csv.data() == [["Alice", "30", "Wonderland"]])
 }
 
 ///|
@@ -38,10 +38,9 @@ test "CSV::from_array/generate_headers" {
     ["Bob", "25", "Builderland"],
   ]
   let csv = CSV::from_array(data, has_header=false, generate_headers=true)
-  inspect(csv.header(), content="[\"column1\", \"column2\", \"column3\"]")
-  inspect(
-    csv.data(),
-    content="[[\"Alice\", \"30\", \"Wonderland\"], [\"Bob\", \"25\", \"Builderland\"]]",
+  assert_true(csv.header() == ["column1", "column2", "column3"])
+  assert_true(
+    csv.data() == [["Alice", "30", "Wonderland"], ["Bob", "25", "Builderland"]],
   )
 }
 
@@ -51,9 +50,9 @@ test "CSV::from_array/first_row_empty_with_header" {
   let data : Array[Array[String]] = [[], []]
   let csv = CSV::from_array(data, has_header=false)
   // 表头应该为空
-  inspect(csv.header(), content="[]")
+  assert_true(csv.header() == [])
   // 数据行应该只包含第二行
-  inspect(csv.data(), content="[[], []]")
+  assert_true(csv.data() == [[], []])
 }
 
 ///|
@@ -63,8 +62,8 @@ test "CSV::from_array/empty_data_with_generate_headers" {
   let csv = CSV::from_array(data, has_header=false, generate_headers=true)
 
   // 由于数据完全为空，column_count=0，所以应该生成空的头
-  inspect(csv.header(), content="[]")
-  inspect(csv.data(), content="[]")
+  assert_true(csv.header() == [])
+  assert_true(csv.data() == [])
 }
 
 ///|
@@ -77,9 +76,9 @@ test "CSV::from_array/first_row_empty" {
   let csv = CSV::from_array(data, has_header=false, generate_headers=true)
 
   // 由于第一行为空，所以column_count=0，不应该生成任何头
-  inspect(csv.header(), content="[]")
+  assert_true(csv.header() == [])
   // 但行数据应该保留
-  inspect(csv.data(), content="[[], [\"Some\", \"Data\", \"Here\"]]")
+  assert_true(csv.data() == [[], ["Some", "Data", "Here"]])
 }
 
 ///|
@@ -92,16 +91,16 @@ test "CSV::from_array/first_row_empty_with_header_no_generate" {
   let csv = CSV::from_array(data, has_header=false, generate_headers=false)
 
   // 表头应该为空
-  inspect(csv.header(), content="[]")
+  assert_true(csv.header() == [])
   // 数据行应该只包含第二行
-  inspect(csv.data(), content="[[], [\"Some\", \"Data\", \"Here\"]]")
+  assert_true(csv.data() == [[], ["Some", "Data", "Here"]])
 }
 
 ///|
 test "CSV::new/basic" {
   let csv = CSV::new()
-  inspect(csv.header(), content="[]")
-  inspect(csv.data(), content="[]")
+  assert_true(csv.header() == [])
+  assert_true(csv.data() == [])
 }
 
 ///|
@@ -111,13 +110,9 @@ test "CSV::parse_string/basic_with_quoted_field" {
     #|John,Doe,120 any st.,"Anytown, WW",08123
     #|
   let csv = CSV::parse_string(data)
-  inspect(
-    csv.header(),
-    content="[\"first\", \"last\", \"address\", \"city\", \"zip\"]",
-  )
-  inspect(
-    csv.data(),
-    content="[[\"John\", \"Doe\", \"120 any st.\", \"Anytown, WW\", \"08123\"]]",
+  assert_true(csv.header() == ["first", "last", "address", "city", "zip"])
+  assert_true(
+    csv.data() == [["John", "Doe", "120 any st.", "Anytown, WW", "08123"]],
   )
 
   // 验证引号字段正确解析
@@ -128,8 +123,8 @@ test "CSV::parse_string/basic_with_quoted_field" {
 test "CSV::parse_string/crlf_with_empty_fields" {
   let data = "a,b,c\r\n1,\"\",\"\"\r\n2,3,4"
   let csv = CSV::parse_string(data)
-  inspect(csv.header(), content="[\"a\", \"b\", \"c\"]")
-  inspect(csv.data(), content="[[\"1\", \"\", \"\"], [\"2\", \"3\", \"4\"]]")
+  assert_true(csv.header() == ["a", "b", "c"])
+  assert_true(csv.data() == [["1", "", ""], ["2", "3", "4"]])
 
   // 验证空引号字段正确解析为空字符串
   assert_eq(csv.data()[0][1], "")
@@ -144,8 +139,8 @@ test "CSV::parse_string/quoted_with_internal_quotes" {
     #|3,4
     #|
   let csv = CSV::parse_string(data)
-  inspect(csv.header(), content="[\"a\", \"b\"]")
-  inspect(csv.data(), content="[[\"1\", \"ha \\\"ha\\\" ha\"], [\"3\", \"4\"]]")
+  assert_true(csv.header() == ["a", "b"])
+  assert_true(csv.data() == [["1", "ha \"ha\" ha"], ["3", "4"]])
 
   // 验证内部引号正确处理
   assert_eq(csv.data()[0][1], "ha \"ha\" ha")
@@ -158,7 +153,7 @@ test "CSV::parse_string/json_in_field" {
     #|1,"{""type"": ""Point"", ""coordinates"": [102.0, 0.5]}"
     #|
   let csv = CSV::parse_string(data)
-  inspect(csv.header(), content="[\"key\", \"val\"]")
+  assert_true(csv.header() == ["key", "val"])
   // 验证JSON字符串被正确解析
   assert_eq(
     csv.data()[0][1],
@@ -173,9 +168,9 @@ test "CSV::parse_string/special_characters" {
     #|2095257564,37�36'37.8"N 121�2'17.9"W,Modesto,Stanislaus
     #|
   let csv = CSV::parse_string(data)
-  inspect(
-    csv.header(),
-    content="[\"Contact Phone Number\", \"Location Coordinates\", \"Cities\", \"Counties\"]",
+  assert_true(
+    csv.header() ==
+    ["Contact Phone Number", "Location Coordinates", "Cities", "Counties"],
   )
   // 验证特殊字符被正确处理
   assert_eq(csv.data()[0][1], "37�36'37.8\"N 121�2'17.9\"W")
@@ -185,7 +180,7 @@ test "CSV::parse_string/special_characters" {
 test "CSV::parse_string/multiline_fields_crlf" {
   let data = "a,b,c\r\n1,2,3\r\n\"Once upon \r\na time\",5,6\r\n7,8,9\r\n"
   let csv = CSV::parse_string(data)
-  inspect(csv.header(), content="[\"a\", \"b\", \"c\"]")
+  assert_true(csv.header() == ["a", "b", "c"])
   // 验证多行字段正确处理
   assert_eq(csv.data()[1][0], "Once upon \r\na time")
 }
@@ -200,7 +195,7 @@ test "CSV::parse_string/multiline_fields_lf" {
     #|7,8,9
     #|
   let csv = CSV::parse_string(data)
-  inspect(csv.header(), content="[\"a\", \"b\", \"c\"]")
+  assert_true(csv.header() == ["a", "b", "c"])
 
   // 验证LF换行符的多行字段正确处理
   let expected =
@@ -213,29 +208,29 @@ test "CSV::parse_string/multiline_fields_lf" {
 test "CSV::parse_string/simple_crlf" {
   let data = "a,b,c\r\n1,2,3\r\n"
   let csv = CSV::parse_string(data)
-  inspect(csv.header(), content="[\"a\", \"b\", \"c\"]")
-  inspect(csv.data(), content="[[\"1\", \"2\", \"3\"]]")
+  assert_true(csv.header() == ["a", "b", "c"])
+  assert_true(csv.data() == [["1", "2", "3"]])
 }
 
 ///|
 test "CSV::parse_string/skips_empty_lines_by_default" {
   let data = "\n\na,b\n\n1,2\r\n\r\n3,4"
   let csv = CSV::parse_string(data)
-  inspect(csv.header(), content="[\"a\", \"b\"]")
-  inspect(csv.data(), content="[[\"1\", \"2\"], [\"3\", \"4\"]]")
+  assert_true(csv.header() == ["a", "b"])
+  assert_true(csv.data() == [["1", "2"], ["3", "4"]])
 }
 
 ///|
 test "CSV::parse_string/preserves_empty_quoted_field_at_eof" {
   let csv = CSV::parse_string("a\n\"\"")
-  inspect(csv.header(), content="[\"a\"]")
-  inspect(csv.data(), content="[[\"\"]]")
+  assert_true(csv.header() == ["a"])
+  assert_true(csv.data() == [[""]])
 }
 
 ///|
 test "CSV::shape/header_only_csv" {
   let csv = CSV::parse_string("a,b\n")
-  inspect(csv.shape(), content="(0, 2)")
+  assert_true(csv.shape() == (0, 2))
 }
 
 ///|
@@ -253,7 +248,7 @@ test "CSV::to_string/escapes_special_fields" {
     #|
   inspect(csv.to_string(), content=expected)
   let reparsed = CSV::parse_string(csv.to_string())
-  inspect(reparsed.header(), content="[\"a\", \"b\", \"c\"]")
+  assert_true(reparsed.header() == ["a", "b", "c"])
   assert_eq(reparsed.data()[0][1], "x,y")
   assert_eq(reparsed.data()[0][2], "say \"hi\"")
   assert_eq(reparsed.data()[1][1], "line\nbreak")
@@ -267,8 +262,8 @@ test "CSV::parse_string/unicode_characters" {
     #|4,5,ʤ
     #|
   let csv = CSV::parse_string(data)
-  inspect(csv.header(), content="[\"a\", \"b\", \"c\"]")
-  inspect(csv.data(), content="[[\"1\", \"2\", \"3\"], [\"4\", \"5\", \"ʤ\"]]")
+  assert_true(csv.header() == ["a", "b", "c"])
+  assert_true(csv.data() == [["1", "2", "3"], ["4", "5", "ʤ"]])
 
   // 验证Unicode字符正确处理
   assert_eq(csv.data()[1][2], "ʤ")
@@ -280,15 +275,15 @@ test "CSV::parse_string/custom_delimiter" {
     #|first;last;address
     #|John;Doe;"120 any st., Anytown"
     #|
-  let csv = CSV::parse_string(data, options=CSVOptions::{
+  let csv = CSV::parse_string(data, options={
     delimiter: ';',
     allow_newlines_in_quotes: true,
     quote_char: '"',
     skip_empty_lines: true,
     trim_spaces: false,
   })
-  inspect(csv.header(), content="[\"first\", \"last\", \"address\"]")
-  inspect(csv.data(), content="[[\"John\", \"Doe\", \"120 any st., Anytown\"]]")
+  assert_true(csv.header() == ["first", "last", "address"])
+  assert_true(csv.data() == [["John", "Doe", "120 any st., Anytown"]])
 
   // 验证自定义分隔符正确工作
   assert_eq(csv.data()[0][2], "120 any st., Anytown")
@@ -300,8 +295,8 @@ test "@nyacsv.CSV::parse_bytes/empty_bytes" {
   let data = Bytes::new(0) // Create an empty byte sequence.
   let csv = @NyaCSV.CSV::parse_bytes(data) // Call the `parse_bytes` function with empty data.
   // Check if the parsed CSV has no headers and no data rows.
-  inspect(csv.header(), content="[]")
-  inspect(csv.data(), content="[]")
+  assert_true(csv.header() == [])
+  assert_true(csv.data() == [])
 }
 
 ///|
@@ -319,5 +314,5 @@ test "@nyacsv.CSV::parse_bytes/single_line_no_header" {
   })
 
   // Check if the parsed CSV has expected data values with an implicit header.
-  inspect(csv.header(), content="[\"value1\", \"value2\", \"value3\"]")
+  assert_true(csv.header() == ["value1", "value2", "value3"])
 }

--- a/parser.mbt
+++ b/parser.mbt
@@ -149,7 +149,7 @@ test "CSV::parse_string/carriage_return_in_quotes" {
   // 测试引号内的\r在允许引号内换行的情况下被保留
   let data = "a,b,c\n1,\"line\rwith\rCRs\",3 "
   let csv = CSV::parse_string(data)
-  inspect(csv.headers, content="[\"a\", \"b\", \"c\"]")
+  assert_true(csv.headers == ["a", "b", "c"])
 
   // 验证引号内的\r被正确保留
   assert_eq(csv.rows[0][1], "line\rwith\rCRs")


### PR DESCRIPTION
## Changes
- Replaced array and tuple `inspect` snapshots with boolean value assertions in CSV tests.
- Removed an unnecessary `CSVOptions::` annotation reported by the stricter MoonBit warning set.

## Why
Recent MoonBit tooling warns when test failure reporting falls back to deprecated `Show` formatting for structured values. The same formatting change also caused snapshot-style assertions for arrays to fail. These tests now compare values directly without relying on deprecated debug output.

## Validation
- `moon check`
- `moon check --warn-list +unnecessary_annotation`
- `moon test`
- `moon fmt`
- `moon info`
- `git diff --check`